### PR TITLE
feat: Allow score update for demo

### DIFF
--- a/inco_contract/CreditScorePII.sol
+++ b/inco_contract/CreditScorePII.sol
@@ -24,6 +24,14 @@ contract CreditScorePII is EIP712WithModifier {
         creditScores[user] = TFHE.asEuint16(encryptedCreditScore);
     }
 
+    // storeDemo is like store, but each user can set/update their own credit,
+    // score, bypassing the trusted agent's access control.
+    // This function is only used for demo purposes in Inco's Confidential DID
+    // demo application.
+    function storeDemo(bytes calldata encryptedCreditScore) external {
+        creditScores[msg.sender] = TFHE.asEuint16(encryptedCreditScore);
+    }
+
     function isUserScoreAbove700(address user) external view returns (bool) {
         ebool isAbove700Encrypted = TFHE.gt(creditScores[user], TFHE.asEuint16(700));
         return TFHE.decrypt(isAbove700Encrypted);


### PR DESCRIPTION
Frontend allows users to update their own credit score for demo purposes. This PR adds this feature on the contract side too.
![Screenshot 2024-03-15 at 11 42 35](https://github.com/Inco-fhevm/Contracts/assets/1293565/cb73c845-4379-4f11-b5a1-7136eab0ee6b)


